### PR TITLE
fix: respect passed in base encoding for toBaseEncodedString

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/ipld/js-cid/issues"
   },
   "dependencies": {
-    "multibase": "^0.2.0",
+    "multibase": "^0.3.0",
     "multicodec": "^0.1.2",
     "multihashes": "^0.3.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -92,13 +92,16 @@ class CID {
     return this.buffer
   }
 
+  toV0String () {
+    return mh.toB58String(this.multihash)
+  }
+
   /* defaults to base58btc */
   toBaseEncodedString (base) {
     base = base || 'base58btc'
 
     switch (this.version) {
       case 0:
-        return mh.toB58String(this.multihash)
       case 1:
         return multibase.encode(base, this.buffer).toString()
       default:

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,11 @@ class CID {
   }
 
   toV0String () {
-    return mh.toB58String(this.multihash)
+    if (this.version === 0) {
+      return mh.toB58String(this.multihash)
+    }
+
+    throw new Error(`Not supported on version: ${this.version}`)
   }
 
   /* defaults to base58btc */

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -17,7 +17,8 @@ describe('CID', () => {
       expect(cid).to.have.property('version', 0)
       expect(cid).to.have.property('multihash').that.eql(multihash.fromB58String(mhStr))
 
-      expect(cid.toBaseEncodedString()).to.be.eql(mhStr)
+      expect(cid.toV0String()).to.be.eql(mhStr)
+      expect(cid.toBaseEncodedString()).to.be.eql('zQmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
     })
 
     it('handles Buffer multihash', (done) => {
@@ -31,7 +32,8 @@ describe('CID', () => {
         expect(cid).to.have.property('version', 0)
         expect(cid).to.have.property('multihash').that.eql(mh)
 
-        expect(cid.toBaseEncodedString()).to.be.eql(mhStr)
+        expect(cid.toV0String()).to.be.eql(mhStr)
+        expect(cid.toBaseEncodedString()).to.be.eql('zQmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4')
         done()
       })
     })
@@ -161,6 +163,50 @@ describe('CID', () => {
       expect(
         CID.isCID(new Buffer('hello world'))
       ).to.be.eql(false)
+    })
+  })
+
+  describe('toBaseEncodedString', () => {
+    const v0 = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
+    const v1 = new CID('zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS')
+
+    it('defaults to base58', () => {
+      expect(
+        v0.toBaseEncodedString()
+      ).to.be.eql(
+        'zQmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
+      )
+
+      expect(
+        v1.toBaseEncodedString()
+      ).to.be.eql(
+        'zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS'
+      )
+    })
+
+    it('respects the passed in encoding', () => {
+      expect(
+        v0.toBaseEncodedString('base16')
+      ).to.be.eql(
+        'f1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      )
+      expect(
+        v0.toBaseEncodedString('base32')
+      ).to.be.eql(
+        'bjcby5qyrbjr7a4csnpx5gitfx3sjbhvza6ize3sngkjfmzdn4ffocv'
+      )
+
+      expect(
+        v1.toBaseEncodedString('base16')
+      ).to.be.eql(
+        'f17012207252523e6591fb8fe553d67ff55a86f84044b46a3e4176e10c58fa529a4aabd5'
+      )
+
+      expect(
+        v1.toBaseEncodedString('base32')
+      ).to.be.eql(
+        'bboajca4sski7glep3r7svhvt76vnin6cais2gupsbo3qqywh2kknevk6v'
+      )
     })
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -209,4 +209,21 @@ describe('CID', () => {
       )
     })
   })
+
+  describe('toV0String', () => {
+    const v0 = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
+    const v1 = new CID('zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS')
+
+    it('v0: returns base58 encoded multihash, without multibase prefix', () => {
+      expect(v0.toV0String()).to.be.eql('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
+    })
+
+    it('v1: throws', () => {
+      expect(
+        () => v1.toV0String()
+      ).to.throw(
+        /Not supported/
+      )
+    })
+  })
 })


### PR DESCRIPTION
This also adds `toV0String`, which generates the legacy base58 encoded multihashes that were previously generated from `toBaseEncodedString`.

If someone has a better name for `toV0String`, I'd love to hear it.

Fixes #13

Depends on js-multibase `master` which hasn't been released yet.

cc @jbenet @diasdavid 