### PR TITLE
fix: throw an error if another base is picked for cidv0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,8 +97,12 @@ class CID {
     base = base || 'base58btc'
 
     switch (this.version) {
-      case 0:
+      case 0: {
+        if (base !== 'base58btc') {
+          throw new Error('not supported with CIDv0, to support different bases, please migrate the instance do CIDv1, you can do that through cid.toV1()')
+        }
         return mh.toB58String(this.multihash)
+      }
       case 1:
         return multibase.encode(base, this.buffer).toString()
       default:

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -50,6 +50,12 @@ describe('CID', () => {
       ).to.throw()
     })
 
+    it('throws on trying to base encode CIDv0 in other base than base58 ', () => {
+      const mhStr = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
+      const cid = new CID(mhStr)
+      expect(() => cid.toBaseEncodedString('base16')).to.throw()
+    })
+
     it('.prefix', () => {
       const cid = new CID(0, 'dag-pb', multihash.encode(new Buffer('abc'), 'sha2-256'))
       expect(cid.prefix.toString('hex')).to.equal('00701203')


### PR DESCRIPTION
Me and @gozala went through details of CID design, v0 vs v1, what does each piece mean and we came with a lot more clarity from that discussion, you can find the log here:

https://botbot.me/freenode/ipfs/2017-01-21/?msg=79711046&page=1

To avoid further confusion, I changed the behaviour of a CIDv0.toBaseEncodedString to only allow base58, throwing an error that informs the user they need to migrate to v1. Added a test for this