### PR TITLE
Fix/to v0 to v1 return cids

### DIFF
--- a/examples/cidv0-to-cidv1.js
+++ b/examples/cidv0-to-cidv1.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const CID = require('../src')
+const multihashStr = 'QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB'
+
+const cidv0 = new CID(multihashStr)
+
+console.log(cidv0.toBaseEncodedString())
+
+const cidv1 = cidv0.toV1()
+
+console.log(cidv1.toBaseEncodedString())

--- a/src/index.js
+++ b/src/index.js
@@ -85,11 +85,15 @@ class CID {
   }
 
   toV0 () {
-    return this.multihash
+    if (this.codec !== 'dag-pb') {
+      throw new Error('Cannot convert a non dag-pb CID to CIDv0')
+    }
+
+    return new CID(0, this.codec, this.multihash)
   }
 
   toV1 () {
-    return this.buffer
+    return new CID(1, this.codec, this.multihash)
   }
 
   /* defaults to base58btc */

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -136,15 +136,11 @@ describe('CID', () => {
     it('.equals v0 to v1 and vice versa', () => {
       const cidV1Str = 'zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS'
       const cidV1 = new CID(cidV1Str)
-      const cidV0 = new CID(cidV1.toV0())
+      const cidV0 = cidV1.toV0()
 
-      expect(
-        cidV0.equals(cidV1)
-      ).to.be.eql(false)
+      expect(cidV0.equals(cidV1)).to.be.false
 
-      expect(
-        cidV1.equals(cidV0)
-      ).to.be.eql(false)
+      expect(cidV1.equals(cidV0)).to.be.false
 
       expect(cidV1.multihash).to.eql(cidV0.multihash)
     })


### PR DESCRIPTION
@gozala, fix the toV0 and toV1 conversation, I agree with you, makes more sense for them to return the full instance.