### PR TITLE
chore: add module Lead Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 > [CID](https://github.com/ipld/cid) implementation in JavaScript.
 
+## Lead Maintainer
+
+[Volker Mische](https://github.com/vmx)
+
 ## Table of Contents
 
 - [Install](#install)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "cids",
   "version": "0.5.3",
   "description": "CID Implementation in JavaScript",
+  "leadMaintainer": "Volker Mische <volker.mische@gmail.com>",
   "main": "src/index.js",
   "scripts": {
     "lint": "aegir lint",
@@ -29,7 +30,6 @@
     "cid",
     "ipld"
   ],
-  "author": "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ipld/js-cid/issues"


### PR DESCRIPTION
The Guidelines for the InterPlanetary JavaScript Projects [1] specify
that there is one Lead Maintainer for every module. This commit add
that information to the repository.

[1]: https://github.com/ipfs/community/blob/master/js-code-guidelines.md