### PR TITLE
Remove direct access to codec lookup table

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "multibase": "~0.4.0",
-    "multicodec": "~0.2.6",
+    "multicodec": "~0.2.7",
     "multihashes": "~0.4.13"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ const mh = require('multihashes')
 const multibase = require('multibase')
 const multicodec = require('multicodec')
 const codecs = require('multicodec/src/base-table')
-const codecVarints = require('multicodec/src/varint-table')
 const multihash = require('multihashes')
 const CIDUtil = require('./cid-util')
 
@@ -120,7 +119,7 @@ class CID {
       case 1:
         return Buffer.concat([
           Buffer.from('01', 'hex'),
-          Buffer.from(codecVarints[this.codec]),
+          multicodec.getCodeVarint(this.codec),
           this.multihash
         ])
       default:
@@ -137,7 +136,7 @@ class CID {
   get prefix () {
     return Buffer.concat([
       Buffer.from(`0${this.version}`, 'hex'),
-      codecVarints[this.codec],
+      multicodec.getCodeVarint(this.codec),
       multihash.prefix(this.multihash)
     ])
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -157,6 +157,14 @@ describe('CID', () => {
       const str = buffer.toString('hex')
       expect(str).to.equals('01711220ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
     })
+
+    it('throws error on unknown codec when base encoding it', () => {
+      expect(() => {
+        new CID(1, 'this-codec-doesnt-exist', hash).toBaseEncodedString()
+      }).to.throw(
+        'Codec `this-codec-doesnt-exist` not found'
+      )
+    })
   })
 
   describe('utilities', () => {


### PR DESCRIPTION
Use `getCodeVarint()` instead of directly accessing the lookup
table of the multicodec module. This leads to nicer error messages
if the given codec is not found.

Prior to this commit:

    buffer.js:183
        throw new TypeError(kFromErrorMsg);
        ^

    TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.
        at Function.Buffer.from (buffer.js:183:11)
        at CID.get buffer [as buffer] (/home/vmx/src/pl/js-cid/src/index.js:123:18)
        at CID.toBaseEncodedString (/home/vmx/src/pl/js-cid/src/index.js:184:44)
        at Object.<anonymous> (/home/vmx/src/pl/js-cid/keccak.js:16:19)
        at Module._compile (module.js:652:30)
        at Object.Module._extensions..js (module.js:663:10)
        at Module.load (module.js:565:32)
        at tryModuleLoad (module.js:505:12)
        at Function.Module._load (module.js:497:3)
        at Function.Module.runMain (module.js:693:10)

With this commit:

    /home/vmx/src/pl/js-multicodec/src/index.js:73
        throw new Error('Codec `' + codecName + '` not found')
        ^

    Error: Codec `mycodec` not found
        at Object.exports.getCodeVarint (/home/vmx/src/pl/js-multicodec/src/index.js:73:11)
        at CID.get buffer [as buffer] (/home/vmx/src/pl/js-cid/src/index.js:121:38)
        at CID.toBaseEncodedString (/home/vmx/src/pl/js-cid/src/index.js:186:44)
        at Object.<anonymous> (/home/vmx/src/pl/js-cid/keccak.js:16:19)
        at Module._compile (module.js:652:30)
        at Object.Module._extensions..js (module.js:663:10)
        at Module.load (module.js:565:32)
        at tryModuleLoad (module.js:505:12)
        at Function.Module._load (module.js:497:3)
        at Function.Module.runMain (module.js:693:10)