### PR TITLE
fix: toV0 and toV1 create instances that cause isCID be false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const withIs = require('class-is')
  * , as defined in [ipld/cid](https://github.com/ipld/cid).
  * @class CID
  */
-class CID {
+const CID = withIs(class {
   /**
    * Create a new CID.
    *
@@ -229,11 +229,11 @@ class CID {
       throw new Error(errorMsg)
     }
   }
-}
-
-CID.codecs = codecs
-
-module.exports = withIs(CID, {
+}, {
   className: 'CID',
   symbolName: '@ipld/js-cid/CID'
 })
+
+CID.codecs = codecs
+
+module.exports = CID

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -198,6 +198,14 @@ describe('CID', () => {
       expect(
         CID.isCID(Buffer.from('hello world'))
       ).to.equal(false)
+
+      expect(
+        CID.isCID(new CID(h1).toV0())
+      ).to.equal(true)
+
+      expect(
+        CID.isCID(new CID(h1).toV1())
+      ).to.equal(true)
     })
 
     it('.toString() outputs default base encoded CID', () => {


### PR DESCRIPTION
The `toV0` and `toV1` functions were returning instances of the unwrapped CID class not the wrapped one with the class-is smarts.