### PR TITLE
fix: add class name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const withIs = require('class-is')
  * , as defined in [ipld/cid](https://github.com/ipld/cid).
  * @class CID
  */
-const CID = withIs(class {
+const CID = withIs(class _CID {
   /**
    * Create a new CID.
    *


### PR DESCRIPTION
JS parser in `aegir docs` is old and doesn't support anonymous classes.