### PR TITLE
chore: remove coverage-publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "release-minor": "aegir release --type minor --docs",
     "release-major": "aegir release --type major --docs",
     "coverage": "aegir coverage",
-    "coverage-publish": "aegir coverage --provider coveralls",
     "docs": "aegir docs"
   },
   "pre-push": [


### PR DESCRIPTION
Coveralls is no longer used on the CI.

This is part of https://github.com/ipfs/aegir/issues/263.